### PR TITLE
SpecInfraのosヘルパーメソッド廃止に対応

### DIFF
--- a/lib/itamae/plugin/recipe/rtn_git/system.rb
+++ b/lib/itamae/plugin/recipe/rtn_git/system.rb
@@ -14,7 +14,7 @@ define :git_install, install_path: nil, archive_url: nil do
   dirname = "git-#{params[:name]}"
 
   packages = %w[wget gcc gettext]
-  case os[:family]
+  case node[:platform]
   when %r(debian|ubuntu)
     packages << 'libssl-dev'
     packages << 'libcurl4-openssl-dev'


### PR DESCRIPTION
[Gosuke Miyashita(@gosukenator)さん | Twitter](https://twitter.com/gosukenator)

> os[:family] の 代わりに node[:platform] を、os[:release] の代わりに node[:platform_version] を使ってください。Serverspec では os メソッドは従来通り使えます。

とのことです。
